### PR TITLE
Fix for 3.4 standard edition

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,149 +20,146 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode->children()
             ->arrayNode('routing')
-            ->useAttributeAsKey('message_class')
-            ->beforeNormalization()
-            ->always()
-            ->then(static function ($config): array {
-                if (!\is_array($config)) {
-                    return [];
-                }
+                ->useAttributeAsKey('message_class')
+                ->beforeNormalization()
+                    ->always()
+                    ->then(static function ($config): array {
+                        if (!\is_array($config)) {
+                            return [];
+                        }
 
-                $newConfig = [];
-                foreach ($config as $k => $v) {
-                    if (!\is_int($k)) {
-                        $newConfig[$k] = [
-                            'senders' => $v['senders'] ?? (\is_array($v) ? \array_values($v) : [$v]),
-                            'send_and_handle' => $v['send_and_handle'] ?? false,
-                        ];
-                    } else {
-                        $newConfig[$v['message-class']]['senders'] = \array_map(
-                            static function ($a) {
-                                return \is_string($a) ? $a : $a['service'];
-                            },
-                            \array_values($v['sender'])
-                        );
-                        $newConfig[$v['message-class']]['send-and-handle'] = $v['send-and-handle'] ?? false;
-                    }
-                }
+                        $newConfig = [];
+                        foreach ($config as $k => $v) {
+                            if (!\is_int($k)) {
+                                $newConfig[$k] = [
+                                    'senders' => $v['senders'] ?? (\is_array($v) ? \array_values($v) : [$v]),
+                                    'send_and_handle' => $v['send_and_handle'] ?? false,
+                                ];
+                            } else {
+                                $newConfig[$v['message-class']]['senders'] = \array_map(
+                                    function ($a) {
+                                        return \is_string($a) ? $a : $a['service'];
+                                    },
+                                    array_values($v['sender'])
+                                );
+                                $newConfig[$v['message-class']]['send-and-handle'] = $v['send-and-handle'] ?? false;
+                            }
+                        }
 
-                return $newConfig;
-            })
-            ->end()
-            ->prototype('array')
-            ->children()
-            ->arrayNode('senders')
-            ->requiresAtLeastOneElement()
-            ->prototype('scalar')->end()
-            ->end()
-            ->booleanNode('send_and_handle')->defaultFalse()->end()
-            ->end()
-            ->end()
+                        return $newConfig;
+                    })
+                ->end()
+                ->prototype('array')
+                    ->children()
+                        ->arrayNode('senders')
+                            ->requiresAtLeastOneElement()
+                            ->prototype('scalar')->end()
+                        ->end()
+                        ->booleanNode('send_and_handle')->defaultFalse()->end()
+                    ->end()
+                ->end()
             ->end()
             ->arrayNode('serializer')
-            ->addDefaultsIfNotSet()
-            ->beforeNormalization()
-            ->always()
-            ->then(static function ($config): array {
-                if (false === $config) {
-                    return ['id' => null];
-                }
+                ->addDefaultsIfNotSet()
+                ->beforeNormalization()
+                    ->always()
+                    ->then(static function ($config): array {
+                        if (false === $config) {
+                            return ['id' => null];
+                        }
 
-                if (\is_string($config)) {
-                    return ['id' => $config];
-                }
+                        if (\is_string($config)) {
+                            return ['id' => $config];
+                        }
 
-                return $config;
-            })
-            ->end()
-            ->children()
-            ->scalarNode('id')->defaultValue(!\class_exists(FullStack::class) && \class_exists(Serializer::class) ? 'messenger.transport.symfony_serializer' : null)->end()
-            ->scalarNode('format')->defaultValue('json')->end()
-            ->arrayNode('context')
-            ->normalizeKeys(false)
-            ->useAttributeAsKey('name')
-            ->defaultValue([])
-            ->prototype('variable')->end()
-            ->end()
-            ->end()
+                        return $config;
+                    })
+                ->end()
+                ->children()
+                    ->scalarNode('id')->defaultValue(!\class_exists(FullStack::class) && \class_exists(Serializer::class) ? 'messenger.transport.symfony_serializer' : null)->end()
+                    ->scalarNode('enabled')->defaultValue(\class_exists(Serializer::class))->end()
+                    ->scalarNode('format')->defaultValue('json')->end()
+                    ->arrayNode('context')
+                        ->normalizeKeys(false)
+                        ->useAttributeAsKey('name')
+                        ->defaultValue([])
+                        ->prototype('variable')->end()
+                    ->end()
+                ->end()
             ->end()
             ->arrayNode('transports')
-            ->useAttributeAsKey('name')
-            ->arrayPrototype()
-            ->beforeNormalization()
-            ->ifString()
-            ->then(static function (string $dsn): array {
-                return ['dsn' => $dsn];
-            })
-            ->end()
-            ->fixXmlConfig('option')
-            ->children()
-            ->scalarNode('dsn')->end()
-            ->arrayNode('options')
-            ->normalizeKeys(false)
-            ->defaultValue([])
-            ->prototype('variable')
-            ->end()
-            ->end()
-            ->end()
-            ->end()
+                ->useAttributeAsKey('name')
+                ->arrayPrototype()
+                    ->beforeNormalization()
+                        ->ifString()
+                        ->then(static function (string $dsn): array {
+                            return ['dsn' => $dsn];
+                        })
+                    ->end()
+                    ->fixXmlConfig('option')
+                    ->children()
+                        ->scalarNode('dsn')->end()
+                        ->arrayNode('options')
+                            ->normalizeKeys(false)
+                            ->defaultValue([])
+                            ->prototype('variable')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
             ->scalarNode('default_bus')->defaultNull()->end()
             ->arrayNode('buses')
-            ->defaultValue(['messenger.bus.default' => ['default_middleware' => true, 'middleware' => []]])
-            ->useAttributeAsKey('name')
-            ->arrayPrototype()
-            ->addDefaultsIfNotSet()
-            ->children()
-            ->enumNode('default_middleware')
-            ->values([true, false, 'allow_no_handlers'])
-            ->defaultTrue()
-            ->end()
-            ->arrayNode('middleware')
-            ->beforeNormalization()
-            ->ifTrue(static function ($v): bool {
-                return \is_string($v) || (\is_array($v) && !\is_int(\key($v)));
-            })
-            ->then(static function ($v): array {
-                return [$v];
-            })
-            ->end()
-            ->defaultValue([])
-            ->arrayPrototype()
-            ->beforeNormalization()
-            ->always()
-            ->then(static function ($middleware): array {
-                if (!\is_array($middleware)) {
-                    return ['id' => $middleware];
-                }
-                if (isset($middleware['id'])) {
-                    return $middleware;
-                }
-                if (1 < \count($middleware)) {
-                    throw new \InvalidArgumentException(\sprintf('Invalid middleware at path "framework.messenger": a map with a single factory id as key and its arguments as value was expected, %s given.', \json_encode($middleware)));
-                }
+                ->defaultValue(['messenger.bus.default' => ['default_middleware' => true, 'middleware' => []]])
+                ->useAttributeAsKey('name')
+                ->arrayPrototype()
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->enumNode('default_middleware')
+                            ->values([true, false, 'allow_no_handlers'])
+                            ->defaultTrue()
+                        ->end()
+                        ->arrayNode('middleware')
+                            ->beforeNormalization()
+                                ->ifTrue(static function ($v): bool { return \is_string($v) || (\is_array($v) && !\is_int(key($v))); })
+                                ->then(static function ($v): array { return [$v]; })
+                            ->end()
+                            ->defaultValue([])
+                            ->arrayPrototype()
+                                ->beforeNormalization()
+                                    ->always()
+                                    ->then(function ($middleware): array {
+                                        if (!\is_array($middleware)) {
+                                            return ['id' => $middleware];
+                                        }
+                                        if (isset($middleware['id'])) {
+                                            return $middleware;
+                                        }
+                                        if (1 < \count($middleware)) {
+                                            throw new \InvalidArgumentException(sprintf('Invalid middleware at path "framework.messenger": a map with a single factory id as key and its arguments as value was expected, %s given.', \json_encode($middleware)));
+                                        }
 
-                return [
-                    'id' => \key($middleware),
-                    'arguments' => \current($middleware),
-                ];
-            })
+                                        return [
+                                            'id' => key($middleware),
+                                            'arguments' => current($middleware),
+                                        ];
+                                    })
+                                ->end()
+                                ->fixXmlConfig('argument')
+                                ->children()
+                                    ->scalarNode('id')->isRequired()->cannotBeEmpty()->end()
+                                    ->arrayNode('arguments')
+                                        ->normalizeKeys(false)
+                                        ->defaultValue([])
+                                        ->prototype('variable')
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
-            ->fixXmlConfig('argument')
-            ->children()
-            ->scalarNode('id')->isRequired()->cannotBeEmpty()->end()
-            ->arrayNode('arguments')
-            ->normalizeKeys(false)
-            ->defaultValue([])
-            ->prototype('variable')
-            ->end()
-            ->end()
-            ->end()
-            ->end()
-            ->end()
-            ->end()
-            ->end()
-            ->end();
+        ->end();
 
         return $treeBuilder;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -37,10 +37,10 @@ final class Configuration implements ConfigurationInterface
                                 ];
                             } else {
                                 $newConfig[$v['message-class']]['senders'] = \array_map(
-                                    function ($a) {
+                                    static function ($a) {
                                         return \is_string($a) ? $a : $a['service'];
                                     },
-                                    array_values($v['sender'])
+                                    \array_values($v['sender'])
                                 );
                                 $newConfig[$v['message-class']]['send-and-handle'] = $v['send-and-handle'] ?? false;
                             }
@@ -140,8 +140,8 @@ final class Configuration implements ConfigurationInterface
                                         }
 
                                         return [
-                                            'id' => key($middleware),
-                                            'arguments' => current($middleware),
+                                            'id' => \key($middleware),
+                                            'arguments' => \current($middleware),
                                         ];
                                     })
                                 ->end()

--- a/src/DependencyInjection/MessengerExtension.php
+++ b/src/DependencyInjection/MessengerExtension.php
@@ -46,13 +46,12 @@ final class MessengerExtension extends ConfigurableExtension
             $container->removeDefinition('messenger.transport.symfony_serializer');
             $container->removeDefinition('messenger.transport.amqp.factory');
         } else {
-            if ($config['serializer']['enabled'] && ('messenger.transport.symfony_serializer' === $config['serializer']['id'] || $config['serializer']['id'] === null)) {
+            if ($config['serializer']['enabled'] && ('messenger.transport.symfony_serializer' === $config['serializer']['id'] || null === $config['serializer']['id'])) {
                 $container->getDefinition('messenger.transport.symfony_serializer')
                     ->replaceArgument(1, $config['serializer']['format'])
                     ->replaceArgument(2, $config['serializer']['context']);
-            }
-
-            if ($config['serializer']['id']) {
+                $container->setAlias('messenger.transport.serializer', 'messenger.transport.symfony_serializer');
+            } elseif (null !== $config['serializer']['id']) {
                 $container->setAlias('messenger.transport.serializer', $config['serializer']['id']);
             } else {
                 $container->removeDefinition('messenger.transport.amqp.factory');


### PR DESCRIPTION
There were some issues with using standard edition since that is a full stack framework and some things weren't the same.

Now there are 2 new keys:

```
serializer:
    enabled: true
validation:
    enabled: true
```

by default, they will be true if the components are there.

Another addition is in the extension if the serializer is enabled but the service `id` is null, we will assume that symfony serializer wants to be used for amqp.