### PR TITLE
Prevent BC Break issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "symfony/dependency-injection": "^3.4 || ^4.0",
     "symfony/framework-bundle": "^3.4 || >=4.0 < 4.1",
     "symfony/http-kernel": "^3.4 || ^4.0",
-    "symfony/messenger": "^4.2 < 4.3"
+    "symfony/messenger": "~4.2.0"
   },
   "require-dev": {
     "behat/behat": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "symfony/dependency-injection": "^3.4 || ^4.0",
     "symfony/framework-bundle": "^3.4 || >=4.0 < 4.1",
     "symfony/http-kernel": "^3.4 || ^4.0",
-    "symfony/messenger": "^4.2"
+    "symfony/messenger": "^4.2 < 4.3"
   },
   "require-dev": {
     "behat/behat": "^3.5",


### PR DESCRIPTION
Since 4.3 is gonna be released this month, this is a way for us to prevent this lib failing as it isn't compatible and if we are planning to support 4.3 it should be a new major.