### PR TITLE
add support for a symfony 3.4 upgraded project

### DIFF
--- a/src/DependencyInjection/MessengerExtension.php
+++ b/src/DependencyInjection/MessengerExtension.php
@@ -147,7 +147,7 @@ final class MessengerExtension extends ConfigurableExtension
         return 'lendable_polyfill_messenger';
     }
     
-    private function registerAliasForArgument(ContainerBuilder $container, string $id, string $type, string $name = null): Alias
+    private function registerAliasForArgument(ContainerBuilder $container, string $id, string $type, string $name = null)
     {
         $name = lcfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name ?? $id))));
 


### PR DESCRIPTION
Is it possible to have a Symfony 3.4 project being upgraded from a symfony 2.8 application. This patch allows this kind of projects to use multiple buses because the registerAliasForArgument method is not present in such version.